### PR TITLE
bugfix: instance reuse when levenshtein dp changes size

### DIFF
--- a/lib/src/Levenshtein.dart
+++ b/lib/src/Levenshtein.dart
@@ -24,6 +24,9 @@ class Levenshtein {
       return;
     }
 
+    length1 = max(this.length1, length1);
+    length2 = max(this.length2, length2);
+
     _dp = List.generate(
         length1 + 1, (i) => List.filled(length2 + 1, 0, growable: false),
         growable: false);
@@ -37,6 +40,9 @@ class Levenshtein {
     for (var k = 0; k < length2 + 1; k++) {
       _dp[0][k] = k;
     }
+
+    this.length1 = length1;
+    this.length2 = length2;
   }
 
   /// Give two words [word1] and [word2], return their Levenshtein distance.

--- a/test/Levenshtein_test.dart
+++ b/test/Levenshtein_test.dart
@@ -29,5 +29,14 @@ void main() {
     test("Completely not match: 'Apple' vs 'Banana'", () {
       expect(levenshtein.distance('Apple', 'Banana'), 6);
     });
+
+    test('Instance reuse when dp array changes size', () {
+      expect(levenshtein.distance('t', 'a-long-string'), 12);
+      expect(
+        () => levenshtein.distance('to', 'short'),
+        isNot(throwsRangeError),
+      );
+      expect(levenshtein.distance('to', 'short'), 4);
+    });
   });
 }


### PR DESCRIPTION
If I reuse the `Woozy` instance (which holds an instance of `Levenshtein`), then it throws a `RangeError`, when its internal "dynamic programming array" (isn't this a matrix?) gets resized.

See test.

I wasn't sure if the `_levenshtein._dp` should only grow or should it be able to shrink, so... I picked the former - only growing.