### PR TITLE
Migrate to null-safety, newer Dart features and more dart-like syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+
+- Migrate to null-safety, use newer dart features (`late` and `required`) and make code more Dart-like
+- Change the name of the generic `T` for a more descriptive `Value`
+
 ## 2.0.0
 
 - Convert from snake-case to lowerCamelCase [PR](https://github.com/IvoriApp/woozy-search/pull/5)

--- a/lib/src/Levenshtein.dart
+++ b/lib/src/Levenshtein.dart
@@ -7,12 +7,12 @@ import 'dart:math';
 class Levenshtein {
   int length1;
   int length2;
-  List<List<int>> _dp;
+  late List<List<int>> _dp;
 
   /// Constructor.
-  Levenshtein() {
-    length1 = 10;
-    length2 = 10;
+  Levenshtein()
+      : length1 = 10,
+        length2 = 10 {
     _resizeDPArray(length1, length2);
   }
 

--- a/lib/src/Models.dart
+++ b/lib/src/Models.dart
@@ -1,21 +1,19 @@
-import 'package:meta/meta.dart';
-
 /// Data class for holding a single input searchable item.
-class InputEntry<T> {
+class InputEntry<Value> {
   /// The original search [text].
   final String text;
 
   /// Optional associate value to the [text] that will be searched on.
-  final T value;
+  final Value? value;
 
   /// A list of words that is tokenized from [text].
-  List<String> _words;
+  late List<String> _words;
 
   /// Reach only list of [words].
   List<String> get words => _words;
 
   /// Constructor of a input entry.
-  InputEntry(this.text, {this.value, @required bool caseSensitive}) {
+  InputEntry(this.text, {this.value, required bool caseSensitive}) {
     _words = text.split(' ');
     if (!caseSensitive) {
       _words = _words.map((word) => word.toLowerCase()).toList();
@@ -24,7 +22,7 @@ class InputEntry<T> {
 }
 
 /// The output search result.
-class MatchResult<T> {
+class MatchResult<Value> {
   /// The [score] of the match result represent how goo the match is.
   ///
   /// Minimum is 0 and maximum is 1.
@@ -34,15 +32,15 @@ class MatchResult<T> {
   final String text;
 
   /// The optional associated [value] of [text].
-  final T value;
+  final Value? value;
 
   /// Constructor.
-  MatchResult(this.score, {@required this.text, @required this.value});
+  MatchResult(this.score, {required this.text, required this.value});
 
   /// For print formatting.
   @override
   String toString() {
-    final textAndScore = 'text: ${text}, score: ${score.toStringAsFixed(2)}';
+    final textAndScore = 'text: $text, score: ${score.toStringAsFixed(2)}';
     if (value != null) {
       return '$textAndScore, value: $value';
     } else {

--- a/lib/src/Woozy.dart
+++ b/lib/src/Woozy.dart
@@ -6,7 +6,7 @@ import 'package:collection/collection.dart';
 import 'Models.dart';
 
 /// The main entry point to the library woozy search.
-class Woozy<T> {
+class Woozy<Value> {
   /// Limit the number of items return from search. Default to 10.
   final int limit;
 
@@ -15,7 +15,7 @@ class Woozy<T> {
   final bool caseSensitive;
 
   /// A list of items to be searched.
-  List<InputEntry<T>> _entries = [];
+  List<InputEntry<Value>> _entries = [];
 
   final Levenshtein _levenshtein = Levenshtein();
 
@@ -34,33 +34,35 @@ class Woozy<T> {
   /// a database id pointing to the entire article.
   /// Example 2, [text] can be a label of an image, and [value] can the filename
   /// of the image.
-  void addEntry(String text, {T value}) {
-    _entries.add(InputEntry(text, value: value, caseSensitive: caseSensitive));
+  void addEntry(String text, {Value? value}) {
+    _entries.add(
+        InputEntry<Value>(text, value: value, caseSensitive: caseSensitive));
   }
 
   /// Add a list of items to be searched for.
   void addEntries(List<String> texts) {
-    _entries
-        .addAll(texts.map((e) => InputEntry(e, caseSensitive: caseSensitive)));
+    _entries.addAll(
+        texts.map((e) => InputEntry<Value>(e, caseSensitive: caseSensitive)));
   }
 
   /// Set the list of items to be searched for. This will overwrite exiting
   /// items.
   void setEntries(List<String> texts) {
-    _entries =
-        texts.map((e) => InputEntry(e, caseSensitive: caseSensitive)).toList();
+    _entries = texts
+        .map((e) => InputEntry<Value>(e, caseSensitive: caseSensitive))
+        .toList();
   }
 
   /// The main search function.
   ///
   /// Given a search query. Return a list of search results.
-  List<MatchResult<T>> search(String query) {
+  List<MatchResult<Value>> search(String query) {
     // Use a heap to keep track of the top `limit` best scores
-    var heapPQ = HeapPriorityQueue<MatchResult<T>>(
+    var heapPQ = HeapPriorityQueue<MatchResult<Value>>(
         (lhs, rhs) => lhs.score.compareTo(rhs.score));
 
     _entries.forEach((entry) {
-      final bestScore = entry.words.fold(0.0, (currentScore, word) {
+      final bestScore = entry.words.fold<double>(0.0, (currentScore, word) {
         final distance = _levenshtein.distance(query, word);
         final maxLength = max(query.length, word.length);
         final score = (maxLength - distance) / maxLength;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,16 @@
 name: woozy_search
 description: A super simple and lightweight client-side fuzzy-search library based on Levenshtein distance.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/IvoriApp/woozy-search
 
 environment:
-  sdk: '>=2.8.1 <3.0.0'
+  sdk: '>=2.12.2 <3.0.0'
 
 dependencies:
   # https://pub.dev/packages/collection
-  collection: '>=1.14.12 <2.0.0'
-  # https://pub.dev/packages/meta
-  meta: '>=1.1.8 <2.0.0'
+  collection: '>=1.15.0 <2.0.0'
 
 dev_dependencies:
-  uuid: ^2.2.0
-  pedantic: ^1.9.0
-  test: ^1.14.4
+  uuid: ^3.0.3
+  pedantic: ^1.11.0
+  test: ^1.16.8

--- a/test/Levenshtein_test.dart
+++ b/test/Levenshtein_test.dart
@@ -2,7 +2,7 @@ import 'package:woozy_search/src/Levenshtein.dart';
 import 'package:test/test.dart';
 
 void main() {
-  Levenshtein levenshtein;
+  late Levenshtein levenshtein;
   setUp(() {
     levenshtein = Levenshtein();
   });


### PR DESCRIPTION
- Dart SDK changed from '>=2.8.1 <3.0.0' to '>=2.12.2 <3.0.0' (null-safety added)
- Removed dependency to meta, as `@required` has to be replaced with `required` due to null-safety related reasons
- Updated dependencies
- Many local/instance variables are modified with `late`, as they are initialised later, but have to be null-safe
- More generics, as types are more strict
- Code is more dart-like (more Dart-like constructors and string interpolation according to the Dart-analyzer)
 - Change the name of the generic `T` to `Value` as it is more descriptive [(source)](https://dart.dev/guides/language/effective-dart/design#do-follow-existing-mnemonic-conventions-when-naming-type-parameters)