### PR TITLE
woozy_results.dart exports the MatchResult class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.3
+
+- Models.dart separated into InputEntry.dart and MatchResult.dart
+- woozy_search.dart exports src/MatchResult.dart
+
 ## 2.0.1
 
 - Migrate to null-safety, use newer dart features (`late` and `required`) and make code more Dart-like

--- a/lib/src/InputEntry.dart
+++ b/lib/src/InputEntry.dart
@@ -1,0 +1,23 @@
+/// Data class for holding a single input searchable item.
+class InputEntry<Value> {
+  /// The original search [text].
+  final String text;
+
+  /// Optional associate value to the [text] that will be searched on.
+  final Value? value;
+
+  /// A list of words that is tokenized from [text].
+  late List<String> _words;
+
+  /// Reach only list of [words].
+  List<String> get words => _words;
+
+  /// Constructor of a input entry.
+  InputEntry(this.text, {this.value, required bool caseSensitive}) {
+    _words = text.split(' ');
+    if (!caseSensitive) {
+      _words = _words.map((word) => word.toLowerCase()).toList();
+    }
+  }
+}
+

--- a/lib/src/MatchResult.dart
+++ b/lib/src/MatchResult.dart
@@ -1,26 +1,3 @@
-/// Data class for holding a single input searchable item.
-class InputEntry<Value> {
-  /// The original search [text].
-  final String text;
-
-  /// Optional associate value to the [text] that will be searched on.
-  final Value? value;
-
-  /// A list of words that is tokenized from [text].
-  late List<String> _words;
-
-  /// Reach only list of [words].
-  List<String> get words => _words;
-
-  /// Constructor of a input entry.
-  InputEntry(this.text, {this.value, required bool caseSensitive}) {
-    _words = text.split(' ');
-    if (!caseSensitive) {
-      _words = _words.map((word) => word.toLowerCase()).toList();
-    }
-  }
-}
-
 /// The output search result.
 class MatchResult<Value> {
   /// The [score] of the match result represent how goo the match is.

--- a/lib/src/Woozy.dart
+++ b/lib/src/Woozy.dart
@@ -1,9 +1,10 @@
 import 'dart:math';
 
-import 'package:woozy_search/src/Levenshtein.dart';
 import 'package:collection/collection.dart';
 
-import 'Models.dart';
+import 'Levenshtein.dart';
+import 'InputEntry.dart';
+import 'MatchResult.dart';
 
 /// The main entry point to the library woozy search.
 class Woozy<Value> {

--- a/lib/woozy_results.dart
+++ b/lib/woozy_results.dart
@@ -1,0 +1,3 @@
+///The result class of the fuzzy-search library if needed somewhere explicitly
+
+export 'src/MatchResult.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: woozy_search
 description: A super simple and lightweight client-side fuzzy-search library based on Levenshtein distance.
-version: 2.0.2
+version: 2.0.3
 homepage: https://github.com/IvoriApp/woozy-search
 
 environment:


### PR DESCRIPTION
- To (explicitly) use the MatchResult class, it was necessary to import out of src, but the source, says it is not a good practice to import out of the src directory ([source](https://dart.dev/guides/language/effective-dart/usage#dont-import-libraries-that-are-inside-the-src-directory-of-another-package))
- The library user might believe that the MatchResult class should only be used inside the library